### PR TITLE
fix(vue): use getter in watch to prevent SSR warning

### DIFF
--- a/packages/vue/src/components/CodeBlock.vue
+++ b/packages/vue/src/components/CodeBlock.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
 
 const codeToHtml = ref("");
 watch(
-	props,
+	() => props,
 	async (val: {
 		code: string;
 		lang: BundledLanguage;


### PR DESCRIPTION
Fixes: https://github.com/selemondev/shiki-code-block/issues/33