### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/shiki-code-block/security/code-scanning/3](https://github.com/selemondev/shiki-code-block/security/code-scanning/3)

In general, fix this by explicitly specifying a minimal `permissions:` block for the workflow or for individual jobs, rather than inheriting repository defaults. For a build‑only workflow that just checks out code and builds/tests, `contents: read` is usually sufficient.

The best minimal fix here is to add a workflow‑level `permissions:` block after the `name: CI` line in `.github/workflows/ci.yml`. This will apply to both `lint` and `test` jobs and restrict the `GITHUB_TOKEN` to read‑only access to repository contents, which is enough for `actions/checkout` and does not alter existing functionality. No additional imports or external methods are needed; this is purely a YAML configuration change within the workflow file.

Concretely: in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: CI`) and line 3 (`on:`). No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions for enhanced security practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->