### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/selemondev/shiki-code-block/security/code-scanning/1](https://github.com/selemondev/shiki-code-block/security/code-scanning/1)

In general, to fix this type of issue you add an explicit `permissions:` block at the workflow root or per job, granting only the minimum scopes required. Since this workflow appears only to need read access to repository contents (it uses tags, checks out code, builds, and then uses external tokens for changelog and npm publishing), we can safely set `contents: read` as the only permission for `GITHUB_TOKEN`.

The best minimal change is to add a `permissions:` block at the top level of `.github/workflows/release.yml` so it applies to all jobs in this workflow. Insert it right after the `name: Release` line and before the `on:` block, as recommended in the background. No imports or additional definitions are needed because this is pure workflow YAML; we are only tightening the `GITHUB_TOKEN`’s scope, not altering any commands or environment variables. The rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for the release process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->